### PR TITLE
[Test] application 테스트 및 커버리지 실행 Gradle 태스크 추가

### DIFF
--- a/linktrip-application/build.gradle.kts
+++ b/linktrip-application/build.gradle.kts
@@ -1,7 +1,49 @@
 plugins {
     id("linktrip-convention")
+    jacoco
 }
 
 dependencies {
     implementation(libs.bundles.domain.application)
+}
+
+val applicationTest =
+    tasks.register<Test>("applicationTest") {
+        description = "Runs tests under com/linktrip/application in the linktrip-application module."
+        group = "verification"
+        testClassesDirs = sourceSets["test"].output.classesDirs
+        classpath = sourceSets["test"].runtimeClasspath
+        include("com/linktrip/application/**")
+        useJUnitPlatform()
+        testLogging {
+            events("passed", "skipped", "failed")
+        }
+    }
+
+val applicationTestCoverage =
+    tasks.register<JacocoReport>("applicationTestCoverage") {
+        description = "Generates JaCoCo coverage for applicationTest."
+        group = "verification"
+        dependsOn(applicationTest)
+        executionData(layout.buildDirectory.file("jacoco/applicationTest.exec"))
+        sourceDirectories.setFrom(files(sourceSets["main"].allSource.srcDirs))
+        classDirectories.setFrom(files(sourceSets["main"].output))
+        reports {
+            xml.required.set(true)
+            csv.required.set(false)
+            html.required.set(true)
+        }
+    }
+
+tasks.test {
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        csv.required.set(false)
+        html.required.set(true)
+    }
 }

--- a/linktrip-domain-test/build.gradle.kts
+++ b/linktrip-domain-test/build.gradle.kts
@@ -1,0 +1,71 @@
+import java.io.ByteArrayOutputStream
+
+fun Project.isWsl(): Boolean {
+    val osRelease = file("/proc/sys/kernel/osrelease")
+    return osRelease.exists() && osRelease.readText().contains("microsoft", ignoreCase = true)
+}
+
+fun Project.openCoverageReport(reportFile: File) {
+    val reportPath = reportFile.absolutePath
+    val osName = System.getProperty("os.name").lowercase()
+
+    when {
+        isWsl() -> {
+            val output = ByteArrayOutputStream()
+            exec {
+                commandLine("wslpath", "-w", reportPath)
+                standardOutput = output
+            }
+            val windowsPath = output.toString().trim()
+            exec {
+                commandLine(
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-Command",
+                    "Start-Process chrome '$windowsPath'",
+                )
+            }
+        }
+        osName.contains("win") -> {
+            exec {
+                commandLine(
+                    "powershell",
+                    "-NoProfile",
+                    "-Command",
+                    "Start-Process chrome '${reportFile.toURI()}'",
+                )
+            }
+        }
+        osName.contains("mac") -> {
+            exec {
+                commandLine("open", "-a", "Google Chrome", reportPath)
+            }
+        }
+        else -> {
+            exec {
+                commandLine("xdg-open", reportPath)
+            }
+        }
+    }
+}
+
+tasks.register("TDD-Application") {
+    group = "test run"
+    description = "Runs all tests in the linktrip-application module with coverage and opens the HTML report."
+
+    doLast {
+        exec {
+            workingDir = file("..")
+            commandLine(
+                "./gradlew",
+                "--rerun-tasks",
+                ":linktrip-application:applicationTest",
+                ":linktrip-application:applicationTestCoverage",
+            )
+        }
+
+        openCoverageReport(
+            file("../linktrip-application/build/reports/jacoco/applicationTestCoverage/html/index.html"),
+        )
+    }
+}

--- a/linktrip-domain-test/build.gradle.kts
+++ b/linktrip-domain-test/build.gradle.kts
@@ -9,43 +9,51 @@ fun Project.openCoverageReport(reportFile: File) {
     val reportPath = reportFile.absolutePath
     val osName = System.getProperty("os.name").lowercase()
 
-    when {
-        isWsl() -> {
-            val output = ByteArrayOutputStream()
-            exec {
-                commandLine("wslpath", "-w", reportPath)
-                standardOutput = output
+    runCatching {
+        when {
+            isWsl() -> {
+                val output = ByteArrayOutputStream()
+                exec {
+                    commandLine("wslpath", "-w", reportPath)
+                    standardOutput = output
+                }
+                val windowsPath = output.toString().trim()
+                exec {
+                    isIgnoreExitValue = true
+                    commandLine(
+                        "powershell.exe",
+                        "-NoProfile",
+                        "-Command",
+                        "Start-Process chrome '$windowsPath'",
+                    )
+                }
             }
-            val windowsPath = output.toString().trim()
-            exec {
-                commandLine(
-                    "powershell.exe",
-                    "-NoProfile",
-                    "-Command",
-                    "Start-Process chrome '$windowsPath'",
-                )
+            osName.contains("win") -> {
+                exec {
+                    isIgnoreExitValue = true
+                    commandLine(
+                        "powershell",
+                        "-NoProfile",
+                        "-Command",
+                        "Start-Process chrome '${reportFile.toURI()}'",
+                    )
+                }
+            }
+            osName.contains("mac") -> {
+                exec {
+                    isIgnoreExitValue = true
+                    commandLine("open", "-a", "Google Chrome", reportPath)
+                }
+            }
+            else -> {
+                exec {
+                    isIgnoreExitValue = true
+                    commandLine("google-chrome", reportPath)
+                }
             }
         }
-        osName.contains("win") -> {
-            exec {
-                commandLine(
-                    "powershell",
-                    "-NoProfile",
-                    "-Command",
-                    "Start-Process chrome '${reportFile.toURI()}'",
-                )
-            }
-        }
-        osName.contains("mac") -> {
-            exec {
-                commandLine("open", "-a", "Google Chrome", reportPath)
-            }
-        }
-        else -> {
-            exec {
-                commandLine("xdg-open", reportPath)
-            }
-        }
+    }.onFailure {
+        logger.warn("Failed to open coverage report automatically: ${it.message}")
     }
 }
 
@@ -54,10 +62,17 @@ tasks.register("TDD-Application") {
     description = "Runs all tests in the linktrip-application module with coverage and opens the HTML report."
 
     doLast {
+        val wrapperCommand =
+            if (System.getProperty("os.name").lowercase().contains("win") && !isWsl()) {
+                "gradlew.bat"
+            } else {
+                "./gradlew"
+            }
+
         exec {
             workingDir = file("..")
             commandLine(
-                "./gradlew",
+                wrapperCommand,
                 "--rerun-tasks",
                 ":linktrip-application:applicationTest",
                 ":linktrip-application:applicationTestCoverage",

--- a/linktrip-domain-test/settings.gradle.kts
+++ b/linktrip-domain-test/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "linktrip-domain-test"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,3 +17,5 @@ include("linktrip-output-cache:caffeine")
 include("linktrip-output-persistence:mysql")
 include("linktrip-output-storage:aws")
 include("linktrip-output-http")
+
+includeBuild("linktrip-domain-test")


### PR DESCRIPTION
## 관련 이슈

- #62

---

## 변경 내용

- `linktrip-domain-test` included build를 추가해 IntelliJ Gradle 창에서 별도 테스트 실행 진입점을 만듬
- `TDD-Application` 태스크를 추가해 `linktrip-application/src/test/kotlin/com/linktrip/application` 하위 테스트만 실행하도록 구성
- `linktrip-application` 모듈에 `applicationTest`, `applicationTestCoverage` 태스크를 추가해 application 테스트와 JaCoCo 커버리지 리포트를 분리 실행할 수 있도록 함
- `TDD-Application` 실행 후 커버리지 HTML 메인 리포트를 자동으로 열도록 구성
- Windows/WSL, macOS, Linux 환경에서 모두 동작할 수 있도록 브라우저 실행 로직을 분기 처리
- JaCoCo 설정에서 deprecated 된 `buildDir` 사용을 `layout.buildDirectory` 기반으로 정리

---

## 체크리스트

- [ ] Ktlint
- [ ] 테스트 통과 여부

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 테스트 커버리지 보고 기능이 추가되었습니다.
  * TDD 워크플로우를 위한 편의 작업이 추가되었습니다.
  * 빌드 구성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->